### PR TITLE
floating point division fix for scrollball scrolling

### DIFF
--- a/converter/keymapless_usb_usb/remix_scrollball.cpp
+++ b/converter/keymapless_usb_usb/remix_scrollball.cpp
@@ -54,8 +54,23 @@ uint8_t remix_loop(void)
 
     if (mse_parser1.time_stamp != last_time_stamp_mse_1)
     {
-        mse_parser1.report.h = mse_parser1.report.x / 2;
-        mse_parser1.report.v = - mse_parser1.report.y / 2;
+        if (mse_parser1.report.x >= -1 && mse_parser1.report.x <= 1)
+        {
+            mse_parser1.report.v = mse_parser1.report.x;
+        }
+        else
+        {
+            mse_parser1.report.h = mse_parser1.report.x / 2;
+        }
+
+        if (mse_parser1.report.y >= -1 && mse_parser1.report.y <= 1)
+        {
+            mse_parser1.report.v = - mse_parser1.report.y;
+        }
+        else
+        {
+            mse_parser1.report.v = - mse_parser1.report.y / 2;
+        }
         mse_parser1.report.x = 0;
         mse_parser1.report.y = 0;
         switch (mse_parser1.report.buttons)


### PR DESCRIPTION
Fixes the problem where slight scrollball scrolls are lost due to 1 getting divided by integer 2 and then cast to zero.